### PR TITLE
Handle taa-marbuta exceptions

### DIFF
--- a/src/hassy_normalizer/rules.py
+++ b/src/hassy_normalizer/rules.py
@@ -45,7 +45,26 @@ def _load_exception_words() -> Set[str]:
     if not isinstance(data, list) or not all(isinstance(x, str) for x in data):
         raise ValueError("exception_words_g_q.json must be a JSON array of strings")
     _LOG.info("Loaded %d exception words", len(data))
-    return set(data)
+    words = set(data)
+
+    # Automatically add taa/haa variants. If a word ends with "ه" and the same
+    # stem with a final "ة" is missing, add it. Likewise add the "ه" form when
+    # only the "ة" form exists.
+    expanded = set(words)
+    for w in words:
+        if w.endswith("ه"):
+            expanded.add(w[:-1] + "ة")
+        elif w.endswith("ة"):
+            expanded.add(w[:-1] + "ه")
+
+    if len(expanded) != len(words):
+        _LOG.info(
+            "Expanded exceptions with taa/haa variants: %d -> %d",
+            len(words),
+            len(expanded),
+        )
+
+    return expanded
 
 
 def load_exceptions() -> Set[str]:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -50,6 +50,15 @@ class TestLetterRules:
             assert apply_letter_rules('قال', exc_hash) == 'قال'  # Exception
             assert apply_letter_rules('قلب', exc_hash) == 'قلب'  # Exception
             assert apply_letter_rules('قرأ', exc_hash) == 'كرأ'  # Not exception
+
+    def test_taa_haa_variant_auto_expansion(self):
+        """Words ending with ه should also match the ة form and vice versa."""
+        # Simulate JSON containing only the "ه" form
+        with patch('hassy_normalizer.rules.load_exceptions', return_value={'القضيه'}):
+            reload_exceptions()
+            assert is_exception_word('القضية') is True
+            # Step 1 should be skipped but step 2 still applies
+            assert apply_letter_rules('القضية') == 'القضيه'
     
     def test_empty_and_whitespace_words(self):
         """Test handling of empty and whitespace-only words."""


### PR DESCRIPTION
## Summary
- handle automatic taa/haa pairs when loading exception words
- test that the exceptions set recognizes both endings
- fix missing newline in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6856b1fd71e8832c8d89e90e10952d03